### PR TITLE
Return processed results of the notebook

### DIFF
--- a/src/notebook_processor.py
+++ b/src/notebook_processor.py
@@ -2,9 +2,15 @@ from src.notebook_parser import NotebookParseResult
 from src.repositories.models import Book, Note
 import hashlib
 from src.repositories.interfaces import BookRepositoryInterface, NoteRepositoryInterface
+from typing import Any, TypedDict
 
 
-def process_notebook_result(result: NotebookParseResult, book_repo: BookRepositoryInterface, note_repo: NoteRepositoryInterface):
+class ProcessedNotebookResult(TypedDict):
+    book: dict[str, str]
+    notes: list[dict[str, Any]]
+
+
+def process_notebook_result(result: NotebookParseResult, book_repo: BookRepositoryInterface, note_repo: NoteRepositoryInterface) -> ProcessedNotebookResult:
     # Create a Book instance
     book = Book(title=result.book_title, author=result.authors_str)
 
@@ -14,9 +20,13 @@ def process_notebook_result(result: NotebookParseResult, book_repo: BookReposito
     if book.id is None:
         raise ValueError("Book ID is None after adding to repository")
 
-    # Iterate over notes and add them to the repository
+    # Collect notes data
+    notes_data: list[dict[str, Any]] = []
     for note_content in result.notes:
         # Generate a stable hash using hashlib
         content_hash = hashlib.sha256(note_content.encode('utf-8')).hexdigest()
         note = Note(content=note_content, content_hash=content_hash, book_id=book.id)
-        note_repo.add(note)
+        note = note_repo.add(note)
+        notes_data.append(note.model_dump(exclude={'created_at'}))
+
+    return ProcessedNotebookResult(book=book.model_dump(exclude={'created_at'}), notes=notes_data)

--- a/src/test_notebook_processor.py
+++ b/src/test_notebook_processor.py
@@ -29,6 +29,7 @@ class StubNoteRepository(NoteRepositoryInterface):
         self.notes: list[Note] = []
 
     def add(self, note: Note) -> Note:
+        note.id = len(self.notes) + 1  # Simulate auto-increment ID
         self.notes.append(note)
         return note
 
@@ -71,3 +72,37 @@ def test_process_notebook_result():
     # Assertions for content_hash
     assert note_repo.notes[0].content_hash == hashlib.sha256("Note 1".encode('utf-8')).hexdigest()
     assert note_repo.notes[1].content_hash == hashlib.sha256("Note 2".encode('utf-8')).hexdigest()
+
+
+def test_process_notebook_result_return_value():
+    # Use stub repositories
+    book_repo = StubBookRepository()
+    note_repo = StubNoteRepository()
+
+    # Create a sample NotebookParseResult
+    result = NotebookParseResult(
+        book_title="Sample Book",
+        authors_str="Author Name",
+        notes=["Note 1", "Note 2"],
+        total_notes=2
+    )
+
+    # Call the function and get the return value
+    returned_value = process_notebook_result(result, book_repo, note_repo)
+
+    # Assertions for the book
+    assert returned_value['book'] == {
+        'id': 1,
+        'title': "Sample Book",
+        'author': "Author Name"
+    }
+
+    # Assertions for the notes
+    expected_notes = [
+        {'id': 1, 'book_id': 1, 'content': "Note 1", 'content_hash': hashlib.sha256("Note 1".encode('utf-8')).hexdigest()},
+        {'id': 2, 'book_id': 1, 'content': "Note 2", 'content_hash': hashlib.sha256("Note 2".encode('utf-8')).hexdigest()}
+    ]
+
+    assert len(returned_value['notes']) == len(expected_notes)
+    for note, expected in zip(returned_value['notes'], expected_notes):
+        assert note == expected


### PR DESCRIPTION
so that the caller can do something about the model representation of
the notes, such as returning to the API client.
