### PR TITLE
Add canonical tweet thread URLs

### DIFF
--- a/src/repositories/models.py
+++ b/src/repositories/models.py
@@ -1,7 +1,9 @@
-from sqlmodel import Field, SQLModel, Relationship, UniqueConstraint, Column, JSON
 from datetime import datetime, timezone
-from pgvector.sqlalchemy import Vector
 from typing import Optional, TYPE_CHECKING, cast, Literal
+
+from pydantic import computed_field
+from pgvector.sqlalchemy import Vector
+from sqlmodel import Column, JSON, Field, Relationship, SQLModel, UniqueConstraint
 from src.types import Embedding
 from src.config import settings
 
@@ -296,6 +298,11 @@ class TweetThreadResponse(SQLModel):
     fetched_at: datetime
     created_at: datetime
 
+    @computed_field
+    @property
+    def canonical_url(self) -> str:
+        return f"https://x.com/i/web/status/{self.root_tweet_id}"
+
 
 # Tweet Models
 
@@ -410,6 +417,11 @@ class TweetThreadSource(SQLModel):
     root_tweet_id: str
     tweet_count: int
     created_at: datetime
+
+    @computed_field
+    @property
+    def canonical_url(self) -> str:
+        return f"https://x.com/i/web/status/{self.root_tweet_id}"
 
 
 # Type alias for source union

--- a/src/routers/test_random_content.py
+++ b/src/routers/test_random_content.py
@@ -197,6 +197,10 @@ async def test_random_v2_tweet_response_structure(
             assert metadata["source"]["id"] == thread.id
             assert metadata["source"]["type"] == "tweet_thread"
             assert metadata["source"]["root_tweet_id"] == "root123"
+            assert (
+                metadata["source"]["canonical_url"]
+                == "https://x.com/i/web/status/root123"
+            )
 
             # Verify content is the tweet
             assert metadata["content"]["id"] == tweet.id

--- a/src/routers/test_search.py
+++ b/src/routers/test_search.py
@@ -265,6 +265,10 @@ def test_search_tweets_single_thread(setup_search_deps: SearchDepsSetup):
 
     # Check thread structure
     assert thread_result["thread"]["root_tweet_id"] == "123456789"
+    assert (
+        thread_result["thread"]["canonical_url"]
+        == "https://x.com/i/web/status/123456789"
+    )
 
     # Check matched tweets
     assert len(thread_result["tweets"]) == 2

--- a/src/routers/test_tweets.py
+++ b/src/routers/test_tweets.py
@@ -231,6 +231,7 @@ def test_get_tweet_thread_empty_tweets(setup_tweet_deps: TweetDepsSetup):
     data = response.json()
     assert data["thread"]["id"] == thread.id
     assert data["thread"]["root_tweet_id"] == "tweet001"
+    assert data["thread"]["canonical_url"] == "https://x.com/i/web/status/tweet001"
     assert data["thread"]["title"] == "My thread"
     assert len(data["tweets"]) == 0
 
@@ -379,6 +380,10 @@ async def test_get_tweet_with_context_stream_success(setup_tweet_deps: TweetDeps
             metadata = events[0]["data"]
             assert metadata["source"]["id"] == thread.id
             assert metadata["source"]["root_tweet_id"] == "tweet001"
+            assert (
+                metadata["source"]["canonical_url"]
+                == "https://x.com/i/web/status/tweet001"
+            )
             assert metadata["source"]["type"] == "tweet_thread"
             assert metadata["content"]["id"] == tweet.id
             assert metadata["content"]["content"] == "Test tweet content"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tweet thread responses now include a canonical URL that provides a direct link to the original X (Twitter) status. This URL is automatically derived from each thread's root tweet ID for easy sharing and reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dfujiwara/kindle-notes-reminder/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->